### PR TITLE
chore: bump up trivy-action to v0.2.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Run Trivy vulnerability scanner in repo mode
-      uses: aquasecurity/trivy-action@0.0.20
+      uses: aquasecurity/trivy-action@0.2.2
       with:
         scan-type: "fs"
         ignore-unfixed: true


### PR DESCRIPTION
https://github.com/aquasecurity/trivy-action/releases/tag/0.2.2