### PR TITLE
chore(deps): bump trivy-action to v0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ In this action, [Trivy](https://github.com/aquasecurity/trivy) scans the depende
 ## Usage
 
 ```
-- uses: knqyf263/trivy-issue-action@v0.0.3
+- uses: knqyf263/trivy-issue-action@v0.0.5
   with:
     # Label name
     # Default: vulnerability (this label must be created in advance)

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Run Trivy vulnerability scanner in repo mode
-      uses: aquasecurity/trivy-action@0.2.5
+      uses: aquasecurity/trivy-action@0.9.2
       with:
         scan-type: "fs"
         ignore-unfixed: true


### PR DESCRIPTION
## Description
bump `trivy-action` to [v0.9.2](https://github.com/aquasecurity/trivy-action/releases/tag/0.9.2)